### PR TITLE
Change status enum to use strings and update database schema

### DIFF
--- a/app/controllers/inbound_webhooks/github_controller.rb
+++ b/app/controllers/inbound_webhooks/github_controller.rb
@@ -5,7 +5,7 @@ module InboundWebhooks
     def create
       if verified_request?
         webhook_record = create_webhook_record
-        webhook_record.processing!
+        webhook_record.status_processing!
 
         # TODO: Add a job to process the webhook
         # InboundWebhooks::Github::HandlerJob.perform_later(webhook_record.id)

--- a/app/models/inbound_webhook.rb
+++ b/app/models/inbound_webhook.rb
@@ -18,16 +18,15 @@
 #
 #  index_inbound_webhooks_on_event               (event)
 #  index_inbound_webhooks_on_inbound_webhook_id  (inbound_webhook_id) UNIQUE
-#  index_inbound_webhooks_on_status              (status)
 #
 class InboundWebhook < ApplicationRecord
-  enum status: {
+  enum :status, {
     pending: "pending",
     processing: "processing",
     processed: "processed",
     failed: "failed",
     unhandled: "unhandled"
-  }, _default: "pending"
+  }, default: "pending", prefix: true
 
   validates :event, :status, :payload, :controller_name, presence: true
   validates :inbound_webhook_id, uniqueness: true, allow_nil: true

--- a/app/models/inbound_webhook.rb
+++ b/app/models/inbound_webhook.rb
@@ -9,7 +9,7 @@
 #  payload            :jsonb            not null
 #  processed_at       :datetime
 #  source_ip          :string
-#  status             :integer          default("pending"), not null
+#  status             :string           default("pending"), not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  inbound_webhook_id :string
@@ -21,7 +21,13 @@
 #  index_inbound_webhooks_on_status              (status)
 #
 class InboundWebhook < ApplicationRecord
-  enum :status, %i[pending processing processed failed unhandled], validate: true
+  enum status: {
+    pending: "pending",
+    processing: "processing",
+    processed: "processed",
+    failed: "failed",
+    unhandled: "unhandled"
+  }, _default: "pending"
 
   validates :event, :status, :payload, :controller_name, presence: true
   validates :inbound_webhook_id, uniqueness: true, allow_nil: true

--- a/db/migrate/20241009222135_change_status_to_be_string_in_inbound_webhooks.rb
+++ b/db/migrate/20241009222135_change_status_to_be_string_in_inbound_webhooks.rb
@@ -1,0 +1,9 @@
+class ChangeStatusToBeStringInInboundWebhooks < ActiveRecord::Migration[7.2]
+  def up
+    change_column :inbound_webhooks, :status, :string, default: "pending", null: false
+  end
+
+  def down
+    change_column :inbound_webhooks, :status, :integer, using: 'status::integer'
+  end
+end

--- a/db/migrate/20241009222135_change_status_to_be_string_in_inbound_webhooks.rb
+++ b/db/migrate/20241009222135_change_status_to_be_string_in_inbound_webhooks.rb
@@ -3,7 +3,6 @@ class ChangeStatusToBeStringInInboundWebhooks < ActiveRecord::Migration[7.2]
     add_column :inbound_webhooks, :status_string, :string, default: "pending", null: false
 
     InboundWebhook.find_each do |webhook|
-      p 'webhook_status:', webhook.status
       webhook.update_column(:status_string, webhook.status.to_s)
     end
 

--- a/db/migrate/20241009222135_change_status_to_be_string_in_inbound_webhooks.rb
+++ b/db/migrate/20241009222135_change_status_to_be_string_in_inbound_webhooks.rb
@@ -1,9 +1,32 @@
 class ChangeStatusToBeStringInInboundWebhooks < ActiveRecord::Migration[7.2]
   def up
-    change_column :inbound_webhooks, :status, :string, default: "pending", null: false
+    add_column :inbound_webhooks, :status_string, :string, default: "pending", null: false
+
+    InboundWebhook.find_each do |webhook|
+      p 'webhook_status:', webhook.status
+      webhook.update_column(:status_string, webhook.status.to_s)
+    end
+
+    remove_column :inbound_webhooks, :status
+    rename_column :inbound_webhooks, :status_string, :status
   end
 
   def down
-    change_column :inbound_webhooks, :status, :integer, using: 'status::integer'
+    add_column :inbound_webhooks, :status_int, :integer
+
+    InboundWebhook.find_each do |webhook|
+      status_int = case webhook.status
+      when "pending" then 0
+      when "processing" then 1
+      when "processed" then 2
+      when "failed" then 3
+      when "unhandled" then 4
+      else 0
+      end
+      webhook.update_column(:status_int, status_int)
+    end
+
+    remove_column :inbound_webhooks, :status
+    rename_column :inbound_webhooks, :status_int, :status
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_09_222135) do
 
   create_table "inbound_webhooks", force: :cascade do |t|
     t.string "event", null: false
-    t.string "status", default: "pending", null: false
     t.jsonb "payload", null: false
     t.string "controller_name", null: false
     t.text "error_message"
@@ -25,8 +24,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_09_222135) do
     t.datetime "processed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status", default: "pending", null: false
     t.index ["event"], name: "index_inbound_webhooks_on_event"
     t.index ["inbound_webhook_id"], name: "index_inbound_webhooks_on_inbound_webhook_id", unique: true
-    t.index ["status"], name: "index_inbound_webhooks_on_status"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_07_25_223324) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_09_222135) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "inbound_webhooks", force: :cascade do |t|
     t.string "event", null: false
-    t.integer "status", default: 0, null: false
+    t.string "status", default: "pending", null: false
     t.jsonb "payload", null: false
     t.string "controller_name", null: false
     t.text "error_message"

--- a/docs/managing_enums.md
+++ b/docs/managing_enums.md
@@ -1,0 +1,166 @@
+# Understanding Enums in Rails
+In Rails, enums are a convenient way to map symbolic names to integer values in the database. By default, when you define an enum in a Rails model, it stores the values as integers.
+
+Example:
+
+```ruby
+class InboundWebhook < ApplicationRecord
+enum status: %i[pending processing processed failed unhandled], validate: true
+end
+```
+This maps:
+
+```ruby
+pending => 0
+processing => 1
+processed => 2
+failed => 3
+unhandled => 4
+```
+
+### Storing Enums as Integers
+**Pros:**
+- Storage Efficiency:
+  - Integers take up less space than strings.
+  - Faster indexing and querying due to smaller data size.
+- Performance:
+  - Numeric comparisons are generally faster.
+  
+**Cons**:
+- Readability:
+  - Database records are less human-readable.
+  - Debugging and manual queries become harder.
+- Mapping Issues:
+  - Changing the order of enum declarations can break data integrity.
+  - Adding new statuses in between existing ones can shift the mappings.
+- Data Migration Risks:
+  - Renaming or reordering enum values requires careful data migration to prevent mismatches.
+  
+### Storing Enums as Strings
+**Pros**:
+- Readability:
+  - Database entries are human-readable. 
+  - Easier to debug and perform manual queries.
+- Flexibility:
+  - Adding new statuses doesn't affect existing data. 
+  - Renaming statuses doesn't require data migration (as long as you keep the string values consistent).
+- Data Integrity:
+  - The actual value is stored, reducing the risk of mapping errors.
+  
+**Cons**:
+- Storage Size:
+  - Strings take up more space than integers.
+  - Might slightly impact performance on very large datasets.
+- Validation:
+  - Need to ensure that only valid strings are stored.
+  - However, Rails enums handle this validation for you.
+  
+### Best Practices
+Given the trade-offs, storing enums as strings is generally considered a better practice, especially for attributes like status that benefit from clarity and flexibility.
+
+**Reasons**:
+- Human-Readable Data:
+  - Easier for developers and database administrators to understand the data directly from the database.
+- Avoiding Mapping Issues:
+  - Prevents bugs related to integer mapping changes when modifying the enum declarations.
+- Ease of Maintenance:
+  - Simplifies adding, removing, or renaming statuses without complex migrations.
+
+### When to Use ActiveRecord Enums
+- Need for Flexibility: 
+  - If your application's enum values are likely to change (e.g., adding new statuses). 
+- Cross-Database Compatibility: 
+  - If you want to keep the option open to switch databases in the future.
+- Simplicity: 
+- If you prefer straightforward migrations and minimal database-specific code.
+- Full Rails Integration: 
+  - If you want to leverage Rails' built-in features without additional setup.
+
+### When to Use PostgreSQL Enums
+- Strict Data Integrity Requirements: 
+  - If it's critical to enforce valid values at the database level.
+- Performance Optimization: 
+  - For large datasets where storage efficiency and indexing are crucial.
+- Database-Centric Design: 
+  - If your application heavily relies on database features and you're committed to PostgreSQL.
+- Schema Clarity: 
+  - When you want the database schema to explicitly define allowed values.
+
+#### Implementation
+- Migration to Create Enum Type
+
+```ruby
+  class CreateStatusEnum < ActiveRecord::Migration[7.0]
+  def up
+    execute <<-SQL
+      CREATE TYPE status AS ENUM ('pending', 'processing', 'processed', 'failed', 'unhandled');
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      DROP TYPE status;
+    SQL
+  end
+end
+```
+
+- Using the Enum in a Table
+
+```ruby
+class AddStatusToInboundWebhooks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :inbound_webhooks, :status, :status, default: 'pending', null: false
+  end
+end
+```
+- Model Definition
+
+```ruby
+class InboundWebhook < ApplicationRecord
+  # You can still use enums for convenience methods
+  enum status: {
+    pending: 'pending',
+    processing: 'processing',
+    processed: 'processed',
+    failed: 'failed',
+    unhandled: 'unhandled'
+  }
+end
+```
+
+**Pros**
+1. Data Integrity
+   - Database-Level Enforcement: The database strictly enforces valid values, preventing invalid data even from direct SQL operations. 
+   - Consistency: Ensures that all data stored conforms to the defined enum.
+2. Performance
+   - Efficient Storage: PostgreSQL stores enums efficiently, often as integers internally.
+   - Indexing: Enums can be indexed effectively, leading to performant queries.
+3. Strong Typing
+   - Schema Clarity: The database schema clearly defines the allowed values for a column.
+   - Validation at Multiple Layers: Both the application and database enforce constraints.
+
+**Cons**
+1. Flexibility
+   - Difficulty in Modifying Enums: Adding or removing enum values requires running migrations and can be complex.
+   - Downtime Risks: Changing enum types may require locking tables, leading to potential downtime.
+2. Database Dependence
+   - Database-Specific: Ties your application closely to PostgreSQL, reducing portability to other databases.
+   - Complex Migrations: Managing enums across different environments (development, staging, production) can be tricky.
+3. ORM Limitations
+   - ActiveRecord Support: Limited built-in support for PostgreSQL enums in Rails migrations and models.
+   - Third-Party Gems: May need to use additional gems or custom code to handle enums smoothly.
+
+### Comparison
+| Aspect               | ActiveRecord Enums                  | PostgreSQL Enums                      |
+|----------------------|-------------------------------------|---------------------------------------|
+| Data Integrity       | Enforced at application level       | Enforced at database level            |
+| Flexibility          | Easy to add/change enum values      | Difficult to modify once defined      |
+| Database Dependency  | Database-agnostic                   | Tied to PostgreSQL                    |
+| Performance          | Good, with potential mapping issues | Efficient storage and indexing        |
+| Migration Complexity | Simple migrations                   | Complex migrations, risk of downtime  |
+| Tooling Support      | Full support in Rails               | Limited support, may need gems        |
+| Readability          | Good with string enums              | Excellent, enforced at schema level   |
+
+#### Resources: 
+- https://naturaily.com/blog/ruby-on-rails-enum

--- a/spec/factories/inbound_webhooks.rb
+++ b/spec/factories/inbound_webhooks.rb
@@ -18,7 +18,6 @@
 #
 #  index_inbound_webhooks_on_event               (event)
 #  index_inbound_webhooks_on_inbound_webhook_id  (inbound_webhook_id) UNIQUE
-#  index_inbound_webhooks_on_status              (status)
 #
 FactoryBot.define do
   factory :inbound_webhook do

--- a/spec/factories/inbound_webhooks.rb
+++ b/spec/factories/inbound_webhooks.rb
@@ -9,7 +9,7 @@
 #  payload            :jsonb            not null
 #  processed_at       :datetime
 #  source_ip          :string
-#  status             :integer          default("pending"), not null
+#  status             :string           default("pending"), not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  inbound_webhook_id :string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The `status` attribute of inbound webhooks has been updated to a string format, enhancing clarity and usability.
	- Default value for `status` is now set to "pending".

- **Bug Fixes**
	- Ensured that the `status` column cannot be null, improving data integrity.

- **Documentation**
	- Added comprehensive guidelines on managing enums in Rails, highlighting best practices for using strings over integers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->