### PR TITLE
Change http client name to faraday_client.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,14 @@ This is a Ruby on Rails application to build a robust, extendable and scalable w
 ### InboundWebhook Model
 The InboundWebhook model is used to store the webhook data and monitor the status of the webhook. Also, it is used to save the error message if the webhook request fails.
 
-### Integrations::HttpClient
-The Integrations::HttpClient is used to make the HTTP request to the relevant API. This class is used to make the HTTP request in the background job. It is designed to handle the response and error while making the request.
+### Integrations::FaradayClient
+The Integrations::FaradayClient is used to make the HTTP request to the relevant API. This class is used to make the HTTP request in the background job. It is designed to handle the response and error while making the request.
+
+#### Integrations::HttpErrorHandling
+This module is responsible for handling errors that are raised by the HTTP client. It defines custom error classes for different types of HTTP errors.
+
+#### Integrations::ApiResponse
+This module is a simple data object that represents an HTTP response. It provides methods to check if the response is successful or a failure based on the HTTP status code.
 
 ### InboundWebhooks::ApplicationController
 The InboundWebhooks::ApplicationController is used to handle the common methods for the InboundWebhooks controllers. This controller is inherited by all the InboundWebhooks controllers. 

--- a/app/services/integrations/api_response.rb
+++ b/app/services/integrations/api_response.rb
@@ -1,23 +1,38 @@
 # frozen_string_literal: true
 
-# ApiResponse class is a simple data object that represents an HTTP response.
-# It provides a success? method that returns true if the response status is in the 200-299 range.
-# It also provides a failure? method that returns true if the response status is outside the 200-299 range.
+# \# ApiResponse class is a simple data object that represents an HTTP response.
+# \# It provides a \#success? method that returns true if the response status is in the 200-299 range.
+# \# It also provides a \#failure? method that returns true if the response status is outside the 200-299 range.
 
 module Integrations
   class ApiResponse
-    attr_reader :status, :body, :error_message
+    # @return [Integer] the HTTP status code of the response
+    attr_reader :status
 
+    # @return [String] the body of the HTTP response
+    attr_reader :body
+
+    # @return [String, nil] the error message, if any
+    attr_reader :error_message
+
+    # Initializes a new ApiResponse object.
+    # @param status [Integer] the HTTP status code of the response
+    # @param body [String] the body of the HTTP response
+    # @param error_message [String, nil] the error message, if any
     def initialize(status:, body:, error_message: nil)
       @status = status
       @body = body
       @error_message = error_message
     end
 
+    # Checks if the response is successful (status code in the 200-299 range).
+    # @return [Boolean] true if the response is successful, false otherwise
     def success?
       (200..299).include?(status)
     end
 
+    # Checks if the response is a failure (status code outside the 200-299 range).
+    # @return [Boolean] true if the response is a failure, false otherwise
     def failure?
       !success?
     end

--- a/app/services/integrations/faraday_client.rb
+++ b/app/services/integrations/faraday_client.rb
@@ -4,7 +4,7 @@
 # It is designed to be included in classes that need to make HTTP requests.
 module Integrations
   module FaradayClient
-    include HttpClientErrors
+    include HttpErrorHanding
 
     # Executes the HTTP request and returns the response.
     # @return [Object] the response object

--- a/app/services/integrations/faraday_client.rb
+++ b/app/services/integrations/faraday_client.rb
@@ -2,9 +2,8 @@
 
 # HttpClient module is a mixin that provides a common interface for making HTTP requests.
 # It is designed to be included in classes that need to make HTTP requests.
-
 module Integrations
-  module HttpClient
+  module FaradayClient
     include HttpClientErrors
 
     # Executes the HTTP request and returns the response.

--- a/app/services/integrations/faraday_client.rb
+++ b/app/services/integrations/faraday_client.rb
@@ -4,7 +4,7 @@
 # It is designed to be included in classes that need to make HTTP requests.
 module Integrations
   module FaradayClient
-    include HttpErrorHanding
+    include HttpErrorHandling
 
     # Executes the HTTP request and returns the response.
     # @return [Object] the response object

--- a/app/services/integrations/http_error_handing.rb
+++ b/app/services/integrations/http_error_handing.rb
@@ -3,7 +3,7 @@
 # This module is used to handle errors that are raised by the HttpClient
 
 module Integrations
-  module HttpClientErrors
+  module HttpErrorHanding
     class ServerError < RuntimeError
       attr_reader :response
 

--- a/app/services/integrations/http_error_handling.rb
+++ b/app/services/integrations/http_error_handling.rb
@@ -3,7 +3,7 @@
 # This module is used to handle errors that are raised by the HttpClient
 
 module Integrations
-  module HttpErrorHanding
+  module HttpErrorHandling
     class ServerError < RuntimeError
       attr_reader :response
 

--- a/spec/services/integrations/dummy_http_client.rb
+++ b/spec/services/integrations/dummy_http_client.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require_relative '../../../app/services/integrations/api_response'
-require_relative '../../../app/services/integrations/http_client_errors'
-require_relative '../../../app/services/integrations/http_client'
+# require_relative '../../../app/services/integrations/api_response'
+# require_relative '../../../app/services/integrations/http_client_errors'
+require_relative '../../../app/services/integrations/faraday_client'
 
 class DummyHttpClient
-  include Integrations::HttpClient
+  include Integrations::FaradayClient
 
   def initialize(base_url)
     @base_url = base_url

--- a/spec/services/integrations/http_client_errors_spec.rb
+++ b/spec/services/integrations/http_client_errors_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../../../app/services/integrations/http_client_errors'
+require_relative '../../../app/services/integrations/http_error_handing'
 
-RSpec.describe Integrations::HttpClientErrors do
+RSpec.describe Integrations::HttpErrorHanding do
   let(:response) { instance_double(Faraday::Response, status: status, body: body) }
   let(:status) { 500 }
   let(:body) { 'Internal Server Error' }
 
-  describe Integrations::HttpClientErrors::ServerError do
+  describe Integrations::HttpErrorHanding::ServerError do
     subject(:error) { described_class.new(response) }
 
     it 'initializes with a response' do
@@ -20,7 +20,7 @@ RSpec.describe Integrations::HttpClientErrors do
     end
   end
 
-  describe Integrations::HttpClientErrors::TimeoutError do
+  describe Integrations::HttpErrorHanding::TimeoutError do
     subject(:error) { described_class.new(response) }
 
     let(:status) { 504 }
@@ -35,7 +35,7 @@ RSpec.describe Integrations::HttpClientErrors do
     end
   end
 
-  describe Integrations::HttpClientErrors::ClientError do
+  describe Integrations::HttpErrorHanding::ClientError do
     subject(:error) { described_class.new(response) }
 
     let(:status) { 400 }

--- a/spec/services/integrations/http_client_errors_spec.rb
+++ b/spec/services/integrations/http_client_errors_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../../../app/services/integrations/http_error_handing'
+require_relative '../../../app/services/integrations/http_error_handling'
 
-RSpec.describe Integrations::HttpErrorHanding do
+RSpec.describe Integrations::HttpErrorHandling do
   let(:response) { instance_double(Faraday::Response, status: status, body: body) }
   let(:status) { 500 }
   let(:body) { 'Internal Server Error' }
 
-  describe Integrations::HttpErrorHanding::ServerError do
+  describe Integrations::HttpErrorHandling::ServerError do
     subject(:error) { described_class.new(response) }
 
     it 'initializes with a response' do
@@ -20,7 +20,7 @@ RSpec.describe Integrations::HttpErrorHanding do
     end
   end
 
-  describe Integrations::HttpErrorHanding::TimeoutError do
+  describe Integrations::HttpErrorHandling::TimeoutError do
     subject(:error) { described_class.new(response) }
 
     let(:status) { 504 }
@@ -35,7 +35,7 @@ RSpec.describe Integrations::HttpErrorHanding do
     end
   end
 
-  describe Integrations::HttpErrorHanding::ClientError do
+  describe Integrations::HttpErrorHandling::ClientError do
     subject(:error) { described_class.new(response) }
 
     let(:status) { 400 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Renamed the HTTP client module from `HttpClient` to `FaradayClient`, maintaining existing functionality.
	- Updated the error handling module name from `HttpClientErrors` to `HttpErrorHandling`.
- **Documentation**
	- Updated the `README.md` to reflect the new HTTP client and introduced sections for error handling and API response.
	- Enhanced documentation for the `ApiResponse` class, clarifying method parameters and return types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->