### PR TITLE
Fix code scanning alert no. 1: CSRF protection weakened or disabled

### DIFF
--- a/app/controllers/inbound_webhooks/application_controller.rb
+++ b/app/controllers/inbound_webhooks/application_controller.rb
@@ -4,8 +4,14 @@ module InboundWebhooks
     # The webhooks are typically sent by external services and do not include CSRF tokens
     # Disabling CSRF protection allows these external requests to be processed without requiring a CSRF token.
     skip_forgery_protection
+    before_action :verify_request
 
     protected
+
+    # Enforce request verification
+    def verify_request
+      head :forbidden unless verified_request?
+    end
 
     # The HMAC header and payload are used to compute and compare signatures to verify the authenticity of the request.
     def verified_request?


### PR DESCRIPTION
Fixes [https://github.com/cuneyter/webhook_integration_app/security/code-scanning/1](https://github.com/cuneyter/webhook_integration_app/security/code-scanning/1)

To fix the problem, we need to ensure that the custom HMAC verification mechanism is enforced for all incoming requests to the controller. This can be achieved by using a `before_action` filter to call the `verified_request?` method before processing any request. If the request is not verified, it should be rejected.

1. Add a `before_action` filter to call the `verified_request?` method.
2. Modify the `verified_request?` method to raise an exception or return an appropriate response if the request is not verified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
