### PR TITLE
Add secure flag to session cookie in production

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -41,7 +41,12 @@ module Authentication
     def start_new_session_for(user)
       user.sessions.create!(user_agent: request.user_agent, ip_address: request.remote_ip).tap do |session|
         Current.session = session
-        cookies.signed.permanent[:session_id] = { value: session.id, httponly: true, same_site: :lax }
+        cookies.signed.permanent[:session_id] = {
+          value: session.id,
+          httponly: true,
+          same_site: :lax,
+          secure: Rails.env.production?
+        }
       end
     end
 


### PR DESCRIPTION
This change adds the `secure: Rails.env.production?` flag to the session cookie configuration in `app/controllers/concerns/authentication.rb`.

This ensures that session cookies are only transmitted over HTTPS connections in production environments, mitigating the risk of session hijacking through network eavesdropping if SSL is terminated upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session cookie security by ensuring cookies are only transmitted over secure connections in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->