### PR TITLE
Add request specs for SessionsController and PasswordsController

### DIFF
--- a/spec/requests/passwords_spec.rb
+++ b/spec/requests/passwords_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Passwords", type: :request do
+  describe "GET /new" do
+    it "returns http success" do
+      get "/passwords/new"
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/requests/passwords_spec.rb
+++ b/spec/requests/passwords_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe "Passwords", type: :request do
   describe "GET /new" do
     it "returns http success" do
-      get "/passwords/new"
+      get new_password_path
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -3,8 +3,9 @@ require 'rails_helper'
 RSpec.describe "Sessions", type: :request do
   describe "GET /new" do
     it "returns http success" do
-      get "/session/new"
+      get new_session_path
       expect(response).to have_http_status(:success)
+      expect(response.body).to include("Sign in")
     end
   end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Sessions", type: :request do
+  describe "GET /new" do
+    it "returns http success" do
+      get "/session/new"
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
This commit introduces request specs for the `new` actions of both the SessionsController and PasswordsController to improve test coverage.

- Added `spec/requests/sessions_spec.rb` to test `GET /session/new`.
- Added `spec/requests/passwords_spec.rb` to test `GET /passwords/new`.

Both specs verify that the respective actions return an HTTP success status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added tests to verify that the password and session creation pages are accessible and respond with a successful status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->