### PR TITLE
Feat: Use I18n for password reset email subject

### DIFF
--- a/app/mailers/passwords_mailer.rb
+++ b/app/mailers/passwords_mailer.rb
@@ -1,6 +1,6 @@
 class PasswordsMailer < ApplicationMailer
   def reset(user)
     @user = user
-    mail subject: "Reset your password", to: user.email_address
+    mail subject: t(".subject"), to: user.email_address
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,3 +29,6 @@
 
 en:
   hello: "Hello world"
+  passwords_mailer:
+    reset:
+      subject: "Reset your password"


### PR DESCRIPTION
- Replaces hard-coded subject string with t(".subject") in PasswordsMailer.
- Adds locale entry for en.passwords_mailer.reset.subject.
- Confirms that password reset emails are already sent asynchronously via deliver_later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Password reset email subject lines are now localised and will appear in the user's selected language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->