### PR TITLE
Fix: Restrict password routes to implemented actions

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,5 @@ Rails.application.routes.draw do
 
   resource :session
   resource :registration, only: %i[new create]
-  resources :passwords, param: :token
+  resources :passwords, only: %i[new create edit update], param: :token
 end


### PR DESCRIPTION
This commit updates config/routes.rb to whitelist only the new, create, edit, and update actions for the passwords resource. This reduces the attack surface and avoids 404s for unimplemented RESTful actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated password management routes to only allow new, create, edit, and update actions, improving route clarity and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->