### PR TITLE
feat: Restrict unauthenticated access in RegistrationsController

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,5 +1,5 @@
 class RegistrationsController < ApplicationController
-  allow_unauthenticated_access
+  allow_unauthenticated_access only: %i[new create]
 
   def new
     @user = User.new


### PR DESCRIPTION
The `allow_unauthenticated_access` in `RegistrationsController` is now scoped to only the `new` and `create` actions. This prevents future actions from being unintentionally exposed to unauthenticated users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted access permissions so that only the registration and account creation pages are accessible without authentication; other actions now require users to be signed in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->