### PR TITLE
feat: Restrict unauthenticated access in PasswordsController

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,5 +1,5 @@
 class PasswordsController < ApplicationController
-  allow_unauthenticated_access
+  allow_unauthenticated_access only: %i[ new create edit update ]
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_url, alert: "Try again later." }
 
   before_action :set_user_by_token, only: %i[ edit update ]


### PR DESCRIPTION
Limits the `allow_unauthenticated_access` in `PasswordsController` to only the `new`, `create`, `edit`, and `update` actions.

This follows the same security approach used in `RegistrationsController` and ensures that only the intended actions are accessible without authentication.