### PR TITLE
Fix: Render edit on password validation failure

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -22,7 +22,7 @@ class PasswordsController < ApplicationController
   end
 
   def update
-    if @user.update(params.permit(:password, :password_confirmation))
+    if @user.update(user_params)
       redirect_to new_session_path, notice: "Password has been reset."
     else
       render :edit, status: :unprocessable_entity
@@ -33,6 +33,10 @@ class PasswordsController < ApplicationController
 
   def password_params
     params.permit(:email_address)
+  end
+
+  def user_params
+    params.require(:user).permit(:password, :password_confirmation)
   end
 
   def set_user_by_token

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -25,7 +25,7 @@ class PasswordsController < ApplicationController
     if @user.update(params.permit(:password, :password_confirmation))
       redirect_to new_session_path, notice: "Password has been reset."
     else
-      redirect_to edit_password_path(params[:token]), alert: "Passwords did not match."
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -3,8 +3,8 @@
 
   <%= form_with model: @user, url: password_path(params[:token]), method: :put, class: "contents" do |form| %>
     <% if form.object.errors.any? %>
-      <div class="text-red-500">
-        <h2>We couldn't save this record because:</h2>
+      <div class="text-red-500" role="alert">
+        <h2><%= pluralize(form.object.errors.count, "error") %> prohibited this password from being updated:</h2>
         <ul>
           <% form.object.errors.full_messages.each do |message| %>
             <li><%= message %></li>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,7 +1,18 @@
 <div class="mx-auto md:w-2/3 w-full">
   <h1 class="font-bold text-4xl">Update your password</h1>
 
-  <%= form_with url: password_path(params[:token]), method: :put, class: "contents" do |form| %>
+  <%= form_with model: @user, url: password_path(params[:token]), method: :put, class: "contents" do |form| %>
+    <% if form.object.errors.any? %>
+      <div class="text-red-500">
+        <h2>We couldn't save this record because:</h2>
+        <ul>
+          <% form.object.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
     <div class="my-5">
       <%= form.password_field :password, required: true, autocomplete: "new-password", placeholder: "Enter new password", maxlength: 72, class: "block shadow rounded-md border border-gray-400 outline-none focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
     </div>

--- a/spec/requests/passwords_spec.rb
+++ b/spec/requests/passwords_spec.rb
@@ -1,10 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe "Passwords", type: :request do
+  let(:user) { create(:user) }
+
   describe "GET /new" do
     it "returns http success" do
       get new_password_path, headers: { "Host" => "localhost" }
       expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "PUT /update" do
+    let(:token) { user.password_reset_token }
+
+    context "with valid params" do
+      it "redirects to the new session path" do
+        put password_path(token), params: { password: "new_password", password_confirmation: "new_password" }
+        expect(response).to redirect_to(new_session_path)
+      end
+    end
+
+    context "with invalid params" do
+      it "renders the edit template" do
+        put password_path(token), params: { password: "new_password", password_confirmation: "invalid" }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
     end
   end
 end

--- a/spec/requests/passwords_spec.rb
+++ b/spec/requests/passwords_spec.rb
@@ -14,15 +14,23 @@ RSpec.describe "Passwords", type: :request do
     let(:token) { user.password_reset_token }
 
     context "with valid params" do
+      let(:valid_params) {
+        { user: { password: "new_password", password_confirmation: "new_password" } }
+      }
+
       it "redirects to the new session path" do
-        put password_path(token), params: { password: "new_password", password_confirmation: "new_password" }
+        put password_path(token), params: valid_params
         expect(response).to redirect_to(new_session_path)
       end
     end
 
     context "with invalid params" do
+      let(:invalid_params) {
+        { user: { password: "new_password", password_confirmation: "invalid" } }
+      }
+
       it "renders the edit template" do
-        put password_path(token), params: { password: "new_password", password_confirmation: "invalid" }
+        put password_path(token), params: invalid_params
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end


### PR DESCRIPTION
Instead of redirecting, render the edit form with a 422 status code when password validation fails in the PasswordsController#update action. This follows Rails conventions and provides a better user experience by displaying validation errors on the form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling on the password update form so that validation errors are now displayed directly on the page, preserving user input and providing clearer feedback.
* **Tests**
  * Added comprehensive tests for password update scenarios, including both successful and failed updates, to ensure correct behaviour and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->